### PR TITLE
Monomod Template Changes & Fixes

### DIFF
--- a/content/Monomod/Hooks/ExampleShoppingCartPatch.cs
+++ b/content/Monomod/Hooks/ExampleShoppingCartPatch.cs
@@ -11,7 +11,7 @@ public class ExampleShoppingCartPatch
     internal static void Init()
     {
         /*
-#if (MMHOOKLocation != "")
+#if (UseHookGen)
          *  Subscribe with 'On.Namespace.Type.Method += CustomMethod;' for each method you're patching.
          *  Or if you are writing an ILHook, use 'IL.' instead of 'On.'
          *  Note that not all types are in a namespace, especially in Unity games.

--- a/content/Monomod/Hooks/ExampleShoppingCartPatch.cs
+++ b/content/Monomod/Hooks/ExampleShoppingCartPatch.cs
@@ -1,20 +1,56 @@
 using System;
 #if (!UseHookGen)
 using HarmonyLib;
+using MonoMod__ModTemplate;
 #endif
 
-namespace MonoMod._ModTemplate.Hooks;
+namespace MonoMod._ModTemplate.Patches;
 
 public class ExampleShoppingCartPatch
 {
-#if (UseHookGen)
-    internal static void AddItemToCart(On.ShoppingCart.orig_AddItemToCart original, ShoppingCart self, ShopItem item)
+    internal static void Init()
+    {
+        /*
+#if (MMHOOKLocation != "")
+         *  Subscribe with 'On.Namespace.Type.Method += CustomMethod;' for each method you're patching.
+         *  Or if you are writing an ILHook, use 'IL.' instead of 'On.'
+         *  Note that not all types are in a namespace, especially in Unity games.
 #else
-    internal static void AddItemToCart(Action<ShoppingCart, ShopItem> original, ShoppingCart self, ShopItem item)
+         *  Add to the Hooks list for each method you're patching with:
+         *  
+#if (PublicizeGameAssemblies)
+         *  Hooks.Add(new Hook(
+         *      typeof(Class).GetMethod(nameof(Class.Method), AccessTools.allDeclared),
+         *      CustomClass.CustomMethod));
+#else
+         *  Hooks.Add(new Hook(
+         *      typeof(Class).GetMethod("Method", AccessTools.allDeclared),
+         *      CustomClass.CustomMethod));
+#endif
+#endif
+         */
+
+#if (UseHookGen)
+        On.ShoppingCart.AddItemToCart += ShoppingCart_AddItemToCart;
+#else
+        Hooks.Add(new Hook(
+#if (PublicizeGameAssemblies)
+                typeof(ShoppingCart).GetMethod(nameof(ShoppingCart.AddItemToCart), AccessTools.allDeclared),
+#else
+                typeof(ShoppingCart).GetMethod("AddItemToCart", AccessTools.allDeclared),
+#endif
+                ExampleShoppingCartPatch.AddItemToCart));
+#endif
+    }
+
+#if (UseHookGen)
+    private static void ShoppingCart_AddItemToCart(On.ShoppingCart.orig_AddItemToCart orig, ShoppingCart self, ShopItem item)
+#else
+    private static void ShoppingCart_AddItemToCart(Action<ShoppingCart, ShopItem> orig, ShoppingCart self, ShopItem item)
 #endif
     {
-        // Call Original Method
-        original(self, item);
+        // Call the Trampoline for the Original method or another method in the Detour Chain if any exist
+        orig(self, item);
 
 #if (PublicizeGameAssemblies)
         /*

--- a/content/Monomod/Hooks/ExampleShoppingCartPatch.cs
+++ b/content/Monomod/Hooks/ExampleShoppingCartPatch.cs
@@ -33,13 +33,17 @@ public class ExampleShoppingCartPatch
 #if (UseHookGen)
         On.ShoppingCart.AddItemToCart += ShoppingCart_AddItemToCart;
 #else
-        AnotherExampleMod.Hooks.Add(new Hook(
+#if (GlobalPluginUsing)
+        Plugin.Hooks.Add(new Hook(
+#else
+        MonoMod__ModTemplate.Hooks.Add(new Hook(
+#endif
 #if (PublicizeGameAssemblies)
                 typeof(ShoppingCart).GetMethod(nameof(ShoppingCart.AddItemToCart), AccessTools.allDeclared),
 #else
                 typeof(ShoppingCart).GetMethod("AddItemToCart", AccessTools.allDeclared),
 #endif
-                ExampleShoppingCartPatch.ShoppingCart_AddItemToCart));
+                ShoppingCart_AddItemToCart));
 #endif
     }
 

--- a/content/Monomod/Hooks/ExampleShoppingCartPatch.cs
+++ b/content/Monomod/Hooks/ExampleShoppingCartPatch.cs
@@ -1,7 +1,7 @@
 using System;
 #if (!UseHookGen)
 using HarmonyLib;
-using MonoMod__ModTemplate;
+using MonoMod.RuntimeDetour;
 #endif
 
 namespace MonoMod._ModTemplate.Patches;
@@ -33,13 +33,13 @@ public class ExampleShoppingCartPatch
 #if (UseHookGen)
         On.ShoppingCart.AddItemToCart += ShoppingCart_AddItemToCart;
 #else
-        Hooks.Add(new Hook(
+        AnotherExampleMod.Hooks.Add(new Hook(
 #if (PublicizeGameAssemblies)
                 typeof(ShoppingCart).GetMethod(nameof(ShoppingCart.AddItemToCart), AccessTools.allDeclared),
 #else
                 typeof(ShoppingCart).GetMethod("AddItemToCart", AccessTools.allDeclared),
 #endif
-                ExampleShoppingCartPatch.AddItemToCart));
+                ExampleShoppingCartPatch.ShoppingCart_AddItemToCart));
 #endif
     }
 

--- a/content/Monomod/MonoMod__ModTemplate.cs
+++ b/content/Monomod/MonoMod__ModTemplate.cs
@@ -9,7 +9,6 @@ using MonoMod.RuntimeDetour.HookGen;
 #else
 using System.Collections.Generic;
 using MonoMod.RuntimeDetour;
-using HarmonyLib;
 #endif
 using MonoMod__ModTemplate.Patches;
 

--- a/content/Monomod/MonoMod__ModTemplate.cs
+++ b/content/Monomod/MonoMod__ModTemplate.cs
@@ -10,7 +10,7 @@ using MonoMod.RuntimeDetour.HookGen;
 using System.Collections.Generic;
 using MonoMod.RuntimeDetour;
 #endif
-using MonoMod__ModTemplate.Patches;
+using MonoMod._ModTemplate.Patches;
 
 namespace MonoMod._ModTemplate;
 

--- a/content/Monomod/MonoMod__ModTemplate.cs
+++ b/content/Monomod/MonoMod__ModTemplate.cs
@@ -36,8 +36,6 @@ public class MonoMod__ModTemplate : BaseUnityPlugin
         Logger.LogInfo($"{MyPluginInfo.PLUGIN_GUID} v{MyPluginInfo.PLUGIN_VERSION} has loaded!");
     }
 
-    
-
     internal static void HookAll()
     {
         Logger.LogDebug("Hooking...");

--- a/content/Monomod/README.md
+++ b/content/Monomod/README.md
@@ -66,8 +66,15 @@ LogLevels = All
 
 This template uses MonoMod. For more specifics on how to use it, look at
 [the MonoMod Examples on lethal.wiki](https://lethal.wiki/dev/fundamentals/patching-code/monomod-examples) and
-[the unofficial MonoMod Documentation on lethal.wiki](https://lethal.wiki/dev/fundamentals/patching-code/monomod-documentation).
-
-Even though these resources are made for the Lethal Company Modding Wiki, they do apply for Content Warning modding. Only things to note are that the CW modding community uses [AutoHookGenPatcher](https://thunderstore.io/c/content-warning/p/Hamunii/AutoHookGenPatcher/) instead of the older [HookGenPatcher](https://github.com/harbingerofme/Bepinex.Monomod.HookGenPatcher), and also that AutoHookGenPatcher already depends on [DetourContext.Dispose Fix](https://thunderstore.io/c/content-warning/p/Hamunii/DetourContext_Dispose_Fix/) on Thunderstore.
+[the unofficial MonoMod Documentation on lethal.wiki](https://lethal.wiki/dev/fundamentals/patching-code/monomod-documentation). Even though these resources are made for the Lethal Company Modding Wiki, they do apply for Content Warning modding.
+<!--#if (!UseHookGen) -->
+Only things to note are that the CW modding community uses [AutoHookGenPatcher](https://thunderstore.io/c/content-warning/p/Hamunii/AutoHookGenPatcher/) instead of the older [HookGenPatcher](https://github.com/harbingerofme/Bepinex.Monomod.HookGenPatcher), and also that AutoHookGenPatcher already depends on [DetourContext.Dispose Fix](https://thunderstore.io/c/content-warning/p/Hamunii/DetourContext_Dispose_Fix/) on Thunderstore.
 
 See [AutoHookGenPatcher - Usage For Developers](https://github.com/Hamunii/BepInEx.MonoMod.AutoHookGenPatcher?tab=readme-ov-file#usage-for-developers) for information on how to generate MMHOOK files for assemblies other than `Assembly-CSharp.dll` or already referenced `MMHOOK` assemblies.
+
+### Notice
+[AutoHookGenPatcher](https://thunderstore.io/c/content-warning/p/Hamunii/AutoHookGenPatcher/) must be installed and set as a dependency on Thunderstore as it will generate the MMHOOK assemblies your plugin depends on.
+
+This can be done by adding the following dependency string in the dependencies of your manifest file when you upload your plugin to Thunderstore:
+`"Hamunii-AutoHookGenPatcher-1.0.3"`. Dependency strings for mods can be found on their Thunderstore pages. 
+<!--#endif -->

--- a/content/Monomod/README.md
+++ b/content/Monomod/README.md
@@ -67,7 +67,7 @@ LogLevels = All
 This template uses MonoMod. For more specifics on how to use it, look at
 [the MonoMod Examples on lethal.wiki](https://lethal.wiki/dev/fundamentals/patching-code/monomod-examples) and
 [the unofficial MonoMod Documentation on lethal.wiki](https://lethal.wiki/dev/fundamentals/patching-code/monomod-documentation). Even though these resources are made for the Lethal Company Modding Wiki, they do apply for Content Warning modding.
-<!--#if (!UseHookGen) -->
+<!--#if (UseHookGen) -->
 Only things to note are that the CW modding community uses [AutoHookGenPatcher](https://thunderstore.io/c/content-warning/p/Hamunii/AutoHookGenPatcher/) instead of the older [HookGenPatcher](https://github.com/harbingerofme/Bepinex.Monomod.HookGenPatcher), and also that AutoHookGenPatcher already depends on [DetourContext.Dispose Fix](https://thunderstore.io/c/content-warning/p/Hamunii/DetourContext_Dispose_Fix/) on Thunderstore.
 
 See [AutoHookGenPatcher - Usage For Developers](https://github.com/Hamunii/BepInEx.MonoMod.AutoHookGenPatcher?tab=readme-ov-file#usage-for-developers) for information on how to generate MMHOOK files for assemblies other than `Assembly-CSharp.dll` or already referenced `MMHOOK` assemblies.

--- a/content/Monomod/README.md
+++ b/content/Monomod/README.md
@@ -1,4 +1,4 @@
-# Content Warning Harmony Template
+# Content Warning MonoMod Template
 
 Thank you for using the mod template! Here are a few tips to help you on your journey:
 
@@ -62,3 +62,12 @@ If you chose to do so, make sure you change the following line in the `BepInEx.c
 LogLevels = All
 ```
 
+## MonoMod
+
+This template uses MonoMod. For more specifics on how to use it, look at
+[the MonoMod Examples on lethal.wiki](https://lethal.wiki/dev/fundamentals/patching-code/monomod-examples) and
+[the unofficial MonoMod Documentation on lethal.wiki](https://lethal.wiki/dev/fundamentals/patching-code/monomod-documentation).
+
+Even though these resources are made for the Lethal Company Modding Wiki, they do apply for Content Warning modding. Only things to note are that the CW modding community uses [AutoHookGenPatcher](https://thunderstore.io/c/content-warning/p/Hamunii/AutoHookGenPatcher/) instead of the older [HookGenPatcher](https://github.com/harbingerofme/Bepinex.Monomod.HookGenPatcher), and also that AutoHookGenPatcher already depends on [DetourContext.Dispose Fix](https://thunderstore.io/c/content-warning/p/Hamunii/DetourContext_Dispose_Fix/) on Thunderstore.
+
+See [AutoHookGenPatcher - Usage For Developers](https://github.com/Hamunii/BepInEx.MonoMod.AutoHookGenPatcher?tab=readme-ov-file#usage-for-developers) for information on how to generate MMHOOK files for assemblies other than `Assembly-CSharp.dll` or already referenced `MMHOOK` assemblies.


### PR DESCRIPTION
- Make separate patch classes handle hooking their patch methods
- MonoMod readme no longer calls itself a Harmony Template
    - Also added some stuff about MonoMod
- Use `HookEndpointManager` for removing all hooks done with HookGen
    - Although this is deprecated in MonoMod's reoganize branch (basically the next version of MonoMod), we are still using what is considered legacy, and we would need HookGenV2 (which is not ready yet) to not need `HookEndpointManager` anyways.
- Rename `namespace MonoMod._ModTemplate.Hooks;` to `namespace MonoMod._ModTemplate.Patches;` because `Hooks` already is a list and we don't want confusing stuff.